### PR TITLE
feat: 공원 지도/검색 API 구현

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,6 @@ name: Feature request
 about: Suggest an idea for this project
 title: "[FEAT]"
 labels: enhancement
-assignees: jnyn0314
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,35 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def generated = 'src/main/generated'
+
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+clean {
+	delete file(generated)
+}
+
+jar {
+	enabled = false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/purureum/pudongpudong/PudongpudongApplication.java
+++ b/src/main/java/purureum/pudongpudong/PudongpudongApplication.java
@@ -3,9 +3,11 @@ package purureum.pudongpudong;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class PudongpudongApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/purureum/pudongpudong/application/command/ParkCommandService.java
+++ b/src/main/java/purureum/pudongpudong/application/command/ParkCommandService.java
@@ -1,0 +1,8 @@
+package purureum.pudongpudong.application.command;
+
+import purureum.pudongpudong.domain.model.Park;
+import reactor.core.publisher.Flux;
+
+public interface ParkCommandService {
+	Flux<Park> saveAllParks();
+}

--- a/src/main/java/purureum/pudongpudong/application/command/ParkCommandServiceImpl.java
+++ b/src/main/java/purureum/pudongpudong/application/command/ParkCommandServiceImpl.java
@@ -1,0 +1,29 @@
+package purureum.pudongpudong.application.command;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import purureum.pudongpudong.domain.model.Park;
+import purureum.pudongpudong.domain.repository.ParkRepository;
+import purureum.pudongpudong.infrastructure.adapter.api.KakaoMapApiService;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ParkCommandServiceImpl implements ParkCommandService{
+	
+	private final ParkRepository parkRepository;
+	private final KakaoMapApiService kakaoMapApiService;
+	
+	@Override
+	public Flux<Park> saveAllParks() {
+		return kakaoMapApiService.getAllParks()
+				.filter(park -> park.getAddressName().startsWith("서울 동대문구"))
+				.flatMap(parkDto -> {
+					Park park = parkDto.toEntity();
+					return Mono.just(parkRepository.save(park));
+		});
+	}
+}

--- a/src/main/java/purureum/pudongpudong/application/query/ParkQueryService.java
+++ b/src/main/java/purureum/pudongpudong/application/query/ParkQueryService.java
@@ -1,4 +1,8 @@
 package purureum.pudongpudong.application.query;
 
+import purureum.pudongpudong.infrastructure.dto.ParkResponseDto;
+import reactor.core.publisher.Flux;
+
 public interface ParkQueryService {
+	Flux<ParkResponseDto> getAllParksWithMyLocation(Double longitude, Double latitude);
 }

--- a/src/main/java/purureum/pudongpudong/application/query/ParkQueryService.java
+++ b/src/main/java/purureum/pudongpudong/application/query/ParkQueryService.java
@@ -1,0 +1,4 @@
+package purureum.pudongpudong.application.query;
+
+public interface ParkQueryService {
+}

--- a/src/main/java/purureum/pudongpudong/application/query/ParkQueryService.java
+++ b/src/main/java/purureum/pudongpudong/application/query/ParkQueryService.java
@@ -1,8 +1,12 @@
 package purureum.pudongpudong.application.query;
 
+import purureum.pudongpudong.infrastructure.dto.ParkDetailResponseDto;
 import purureum.pudongpudong.infrastructure.dto.ParkResponseDto;
 import reactor.core.publisher.Flux;
 
+import java.util.List;
+
 public interface ParkQueryService {
 	Flux<ParkResponseDto> getAllParksWithMyLocation(Double longitude, Double latitude);
+	List<ParkDetailResponseDto> searchParksByKeyword(String keyword);
 }

--- a/src/main/java/purureum/pudongpudong/application/query/ParkQueryServiceImpl.java
+++ b/src/main/java/purureum/pudongpudong/application/query/ParkQueryServiceImpl.java
@@ -1,11 +1,65 @@
 package purureum.pudongpudong.application.query;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import purureum.pudongpudong.domain.model.Park;
+import purureum.pudongpudong.domain.repository.ParkRepository;
+import purureum.pudongpudong.infrastructure.adapter.api.KakaoNaviApiService;
+import purureum.pudongpudong.infrastructure.dto.ParkResponseDto;
+import purureum.pudongpudong.infrastructure.dto.api.KakaoNaviApiRequestDto;
+import purureum.pudongpudong.infrastructure.dto.api.KakaoNaviApiResponseDto;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
-public class ParkQueryServiceImpl {
+@Transactional(readOnly = true)
+public class ParkQueryServiceImpl implements ParkQueryService {
+	
+	private final ParkRepository parkRepository;
+	private final KakaoNaviApiService kakaoNaviApiService;
+	
+	@Override
+	public Flux<ParkResponseDto> getAllParksWithMyLocation(Double longitude, Double latitude) {
+		// TODO: 유저 정보 추가하여 반환
+		return Mono.fromCallable(parkRepository::findAll)
+				.subscribeOn(Schedulers.boundedElastic())
+				.flatMapMany(allParks -> {
+					List<List<Park>> parks = IntStream.range(0, allParks.size())
+							.boxed()
+							.collect(Collectors.groupingBy(i -> i/15))
+							.values()
+							.stream()
+							.map(list -> list.stream().map(allParks::get).collect(Collectors.toList()))
+							.toList();
+					
+					return Flux.fromIterable(parks)
+							.flatMap(parkList -> {
+								List<KakaoNaviApiRequestDto.Destination> destinations = parkList.stream()
+										.map(park -> new KakaoNaviApiRequestDto.Destination(
+												park.getId(), String.valueOf(park.getLongitude()), String.valueOf(park.getLatitude())
+										)).toList();
+								
+								Mono<KakaoNaviApiResponseDto> responses = kakaoNaviApiService.getWalkingRoutes(destinations, longitude, latitude);
+								return Mono.zip(Mono.just(parkList), responses)
+										.flatMapMany(t -> {
+											
+											List<Park> t1 = t.getT1();
+											List<KakaoNaviApiResponseDto.Route> t2 = t.getT2().getRoutes();
+											
+											return Flux.fromIterable(t1)
+													.zipWith(Flux.fromIterable(t2))
+													.map(tuple -> ParkResponseDto.toDto(tuple.getT1(), tuple.getT2()));
+										});
+							});
+				});
+	}
 }

--- a/src/main/java/purureum/pudongpudong/application/query/ParkQueryServiceImpl.java
+++ b/src/main/java/purureum/pudongpudong/application/query/ParkQueryServiceImpl.java
@@ -1,0 +1,11 @@
+package purureum.pudongpudong.application.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ParkQueryServiceImpl {
+}

--- a/src/main/java/purureum/pudongpudong/domain/model/Fairy.java
+++ b/src/main/java/purureum/pudongpudong/domain/model/Fairy.java
@@ -1,0 +1,27 @@
+package purureum.pudongpudong.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import purureum.pudongpudong.global.common.domain.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Fairy extends BaseEntity {
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@Column(nullable = false)
+	private String name;
+	
+	@Column(nullable = false)
+	private String description;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "park_id", nullable = true)
+	private Park park;
+}

--- a/src/main/java/purureum/pudongpudong/domain/model/Fairy.java
+++ b/src/main/java/purureum/pudongpudong/domain/model/Fairy.java
@@ -21,7 +21,7 @@ public class Fairy extends BaseEntity {
 	@Column(nullable = false)
 	private String description;
 	
-	@ManyToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "park_id", nullable = true)
 	private Park park;
 }

--- a/src/main/java/purureum/pudongpudong/domain/model/Park.java
+++ b/src/main/java/purureum/pudongpudong/domain/model/Park.java
@@ -40,4 +40,8 @@ public class Park extends BaseEntity {
 	@Builder.Default
 	@OneToMany(mappedBy = "park", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Fairy> fairies = new ArrayList<>();
+	
+	@Builder.Default
+	@OneToMany(mappedBy = "park", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Review> reviews = new ArrayList<>();
 }

--- a/src/main/java/purureum/pudongpudong/domain/model/Park.java
+++ b/src/main/java/purureum/pudongpudong/domain/model/Park.java
@@ -5,6 +5,9 @@ import lombok.*;
 import purureum.pudongpudong.domain.model.enums.ParkDifficulty;
 import purureum.pudongpudong.global.common.domain.BaseEntity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -25,14 +28,15 @@ public class Park extends BaseEntity {
 	@Column(nullable = false, length = 100)
 	private String description;
 	
+	@Enumerated(EnumType.STRING)
+	private ParkDifficulty difficulty;
+	
 	@Column(columnDefinition = "DECIMAL(10, 7)", nullable = false)
 	private Double longitude;
 	
 	@Column(columnDefinition = "DECIMAL(10, 7)", nullable = false)
 	private Double latitude;
 	
-	private String placeUrl;
-	
-	@Enumerated(EnumType.STRING)
-	private ParkDifficulty difficulty;
+	@OneToMany(mappedBy = "fairy", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Fairy> fairies = new ArrayList<>();
 }

--- a/src/main/java/purureum/pudongpudong/domain/model/Park.java
+++ b/src/main/java/purureum/pudongpudong/domain/model/Park.java
@@ -1,0 +1,38 @@
+package purureum.pudongpudong.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import purureum.pudongpudong.domain.model.enums.ParkDifficulty;
+import purureum.pudongpudong.global.common.domain.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Park extends BaseEntity {
+	
+	@Id
+	private String id;
+	
+	@Column(nullable = false, length = 50)
+	private String placeName;
+	
+	private String addressName;
+	
+	private String roadAddressName;
+	
+	@Column(nullable = false, length = 100)
+	private String description;
+	
+	@Column(columnDefinition = "DECIMAL(10, 7)", nullable = false)
+	private Double longitude;
+	
+	@Column(columnDefinition = "DECIMAL(10, 7)", nullable = false)
+	private Double latitude;
+	
+	private String placeUrl;
+	
+	@Enumerated(EnumType.STRING)
+	private ParkDifficulty difficulty;
+}

--- a/src/main/java/purureum/pudongpudong/domain/model/Park.java
+++ b/src/main/java/purureum/pudongpudong/domain/model/Park.java
@@ -2,9 +2,9 @@ package purureum.pudongpudong.domain.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import purureum.pudongpudong.domain.model.enums.ParkDifficulty;
 import purureum.pudongpudong.global.common.domain.BaseEntity;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,9 +37,13 @@ public class Park extends BaseEntity {
 	@Column(columnDefinition = "DECIMAL(10, 7)", nullable = false)
 	private Double latitude;
 	
+	@OneToOne(mappedBy = "park", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+	private Fairy fairy;
+	
 	@Builder.Default
 	@OneToMany(mappedBy = "park", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Fairy> fairies = new ArrayList<>();
+	@BatchSize(size = 100)
+	private List<ParkTag> parkTags = new ArrayList<>();
 	
 	@Builder.Default
 	@OneToMany(mappedBy = "park", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/purureum/pudongpudong/domain/model/Park.java
+++ b/src/main/java/purureum/pudongpudong/domain/model/Park.java
@@ -37,6 +37,7 @@ public class Park extends BaseEntity {
 	@Column(columnDefinition = "DECIMAL(10, 7)", nullable = false)
 	private Double latitude;
 	
-	@OneToMany(mappedBy = "fairy", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	@OneToMany(mappedBy = "park", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Fairy> fairies = new ArrayList<>();
 }

--- a/src/main/java/purureum/pudongpudong/domain/model/ParkTag.java
+++ b/src/main/java/purureum/pudongpudong/domain/model/ParkTag.java
@@ -15,10 +15,10 @@ public class ParkTag extends BaseEntity {
 	private Long id;
 	
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "park_id")
+	@JoinColumn(name = "park_id", nullable = false)
 	private Park park;
 	
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "tag_id")
+	@JoinColumn(name = "tag_id", nullable = false)
 	private Tag tag;
 }

--- a/src/main/java/purureum/pudongpudong/domain/model/ParkTag.java
+++ b/src/main/java/purureum/pudongpudong/domain/model/ParkTag.java
@@ -1,0 +1,24 @@
+package purureum.pudongpudong.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import purureum.pudongpudong.global.common.domain.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ParkTag extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "park_id")
+	private Park park;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "tag_id")
+	private Tag tag;
+}

--- a/src/main/java/purureum/pudongpudong/domain/model/Review.java
+++ b/src/main/java/purureum/pudongpudong/domain/model/Review.java
@@ -1,0 +1,32 @@
+package purureum.pudongpudong.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import purureum.pudongpudong.global.common.domain.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Review  extends BaseEntity {
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@Column(nullable = false)
+	private Double rating;
+	
+	@Column(nullable = false)
+	private String content;
+	
+	@Column(nullable = false)
+	private Integer likeCount;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "park_id", nullable = false)
+	private Park park;
+	
+	// TODO: 유저 매핑
+}

--- a/src/main/java/purureum/pudongpudong/domain/model/Tag.java
+++ b/src/main/java/purureum/pudongpudong/domain/model/Tag.java
@@ -1,0 +1,19 @@
+package purureum.pudongpudong.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import purureum.pudongpudong.global.common.domain.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Tag extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@Column(nullable = false, length = 20)
+	private String name;
+}

--- a/src/main/java/purureum/pudongpudong/domain/model/enums/ParkDifficulty.java
+++ b/src/main/java/purureum/pudongpudong/domain/model/enums/ParkDifficulty.java
@@ -1,0 +1,5 @@
+package purureum.pudongpudong.domain.model.enums;
+
+public enum ParkDifficulty {
+	EASY, NORMAL, DIFFICULT
+}

--- a/src/main/java/purureum/pudongpudong/domain/repository/ParkRepository.java
+++ b/src/main/java/purureum/pudongpudong/domain/repository/ParkRepository.java
@@ -1,0 +1,9 @@
+package purureum.pudongpudong.domain.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import purureum.pudongpudong.domain.model.Park;
+
+public interface ParkRepository extends JpaRepository<Park, String> {
+
+}

--- a/src/main/java/purureum/pudongpudong/domain/repository/ParkRepository.java
+++ b/src/main/java/purureum/pudongpudong/domain/repository/ParkRepository.java
@@ -1,9 +1,14 @@
 package purureum.pudongpudong.domain.repository;
 
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import purureum.pudongpudong.domain.model.Park;
 
-public interface ParkRepository extends JpaRepository<Park, String> {
+import java.util.List;
 
+
+public interface ParkRepository extends JpaRepository<Park, String> {
+	@EntityGraph(attributePaths = {"fairy", "reviews"})
+	List<Park> findParksByPlaceNameContaining(String keyword);
 }

--- a/src/main/java/purureum/pudongpudong/global/apiPayload/code/PageResponse.java
+++ b/src/main/java/purureum/pudongpudong/global/apiPayload/code/PageResponse.java
@@ -1,0 +1,26 @@
+package purureum.pudongpudong.global.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PageResponse<T> {
+	
+	private List<T> content;
+	private long totalElements;
+	private boolean isLast;
+	private int totalPages;
+	
+	public static <T> PageResponse<T> fromPage (Page<T> page) {
+		return new PageResponse<>(
+				page.getContent(),
+				page.getTotalElements(),
+				page.isLast(),
+				page.getTotalPages()
+		);
+	}
+}

--- a/src/main/java/purureum/pudongpudong/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/purureum/pudongpudong/global/apiPayload/code/status/ErrorStatus.java
@@ -14,7 +14,14 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    
+    // 외부 API 관련 응답
+    KAKAO_MAP_API_BAD_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "KAKAO4001", "카카오 맵 API 호출을 잘못된 요청으로 인해 실패했습니다."),
+    KAKAO_MAP_API_SERVER_ERROR(HttpStatus.BAD_REQUEST, "KAKAO5001", "카카오 맵 API 호출을 서버 에러로 인해 실패했습니다."),
+    KAKAO_NAVI_API_BAD_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "KAKAO4002", "카카오 네비 API 호출을 잘못된 요청으로 인해 실패했습니다."),
+    KAKAO_NAVI_API_SERVER_ERROR(HttpStatus.BAD_REQUEST, "KAKAO5002", "카카오 네비 API 호출을 서버 에러로 인해 실패했습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/purureum/pudongpudong/global/apiPayload/exception/handler/ApiHandler.java
+++ b/src/main/java/purureum/pudongpudong/global/apiPayload/exception/handler/ApiHandler.java
@@ -1,0 +1,11 @@
+package purureum.pudongpudong.global.apiPayload.exception.handler;
+
+import purureum.pudongpudong.global.apiPayload.code.BaseErrorCode;
+import purureum.pudongpudong.global.apiPayload.exception.GeneralException;
+
+public class ApiHandler extends GeneralException {
+	
+	public ApiHandler(BaseErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/purureum/pudongpudong/global/config/QuerydslConfig.java
+++ b/src/main/java/purureum/pudongpudong/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package purureum.pudongpudong.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+	
+	@PersistenceContext
+	private EntityManager entityManager;
+	
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/purureum/pudongpudong/global/config/SecurityConfig.java
+++ b/src/main/java/purureum/pudongpudong/global/config/SecurityConfig.java
@@ -18,7 +18,8 @@ public class SecurityConfig {
 			"/api/auth/**",
 			"/swagger-ui/**",
 			"/v3/api-docs/**",
-			"/swagger-resources/**"
+			"/swagger-resources/**",
+			"/api/**" // TODO: 로그인 구현 후 수정 필요
 	};
 	
 	@Bean

--- a/src/main/java/purureum/pudongpudong/infrastructure/adapter/api/KakaoMapApiService.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/adapter/api/KakaoMapApiService.java
@@ -1,0 +1,51 @@
+package purureum.pudongpudong.infrastructure.adapter.api;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import purureum.pudongpudong.infrastructure.dto.KakaoMapApiResponse;
+import purureum.pudongpudong.infrastructure.dto.ParkDto;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+public class KakaoMapApiService {
+
+	private final WebClient webClient;
+	private final String mapApiKey;
+	
+	public KakaoMapApiService(WebClient.Builder webClientBuilder,
+                              @Value("${kakao.map.url}") String mapApiUrl,
+							  @Value("${kakao.map.key}") String mapApiKey) {
+		this.webClient = webClientBuilder.baseUrl(mapApiUrl).build();
+		this.mapApiKey = mapApiKey;
+	}
+	
+	public Flux<ParkDto> getAllParks() {
+		AtomicInteger page = new AtomicInteger(1);
+		
+		return getParksByPage(page.get())
+				.expand(response -> {
+					if (response.getMeta().isEnd()) {
+						return Mono.empty();
+					}
+					return getParksByPage(page.getAndIncrement());
+				})
+				.flatMap(response -> Flux.fromIterable(response.getParks()));
+	}
+	
+	private Mono<KakaoMapApiResponse> getParksByPage(int page) {
+		return webClient.get()
+				.uri(uriBuilder -> uriBuilder
+						.path("/v2/local/search/keyword.json")
+						.queryParam("query", "동대문구 공원")
+						.queryParam("rect", "127.009,37.550,127.098,37.600")
+						.queryParam("page", page)
+						.build())
+				.header("Authorization", "KakaoAK " + mapApiKey)
+				.retrieve()
+				.bodyToMono(KakaoMapApiResponse.class);
+	}
+}

--- a/src/main/java/purureum/pudongpudong/infrastructure/adapter/api/KakaoMapApiService.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/adapter/api/KakaoMapApiService.java
@@ -3,7 +3,7 @@ package purureum.pudongpudong.infrastructure.adapter.api;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import purureum.pudongpudong.infrastructure.dto.KakaoMapApiResponse;
+import purureum.pudongpudong.infrastructure.dto.api.KakaoMapApiResponseDto;
 import purureum.pudongpudong.infrastructure.dto.ParkDto;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -14,13 +14,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class KakaoMapApiService {
 
 	private final WebClient webClient;
-	private final String mapApiKey;
+	private final String kakaoApiKey;
 	
 	public KakaoMapApiService(WebClient.Builder webClientBuilder,
                               @Value("${kakao.map.url}") String mapApiUrl,
-							  @Value("${kakao.map.key}") String mapApiKey) {
+							  @Value("${kakao.api.key}") String kakaoApiKey) {
 		this.webClient = webClientBuilder.baseUrl(mapApiUrl).build();
-		this.mapApiKey = mapApiKey;
+		this.kakaoApiKey = kakaoApiKey;
 	}
 	
 	public Flux<ParkDto> getAllParks() {
@@ -36,7 +36,7 @@ public class KakaoMapApiService {
 				.flatMap(response -> Flux.fromIterable(response.getParks()));
 	}
 	
-	private Mono<KakaoMapApiResponse> getParksByPage(int page) {
+	private Mono<KakaoMapApiResponseDto> getParksByPage(int page) {
 		return webClient.get()
 				.uri(uriBuilder -> uriBuilder
 						.path("/v2/local/search/keyword.json")
@@ -44,8 +44,8 @@ public class KakaoMapApiService {
 						.queryParam("rect", "127.009,37.550,127.098,37.600")
 						.queryParam("page", page)
 						.build())
-				.header("Authorization", "KakaoAK " + mapApiKey)
+				.header("Authorization", "KakaoAK " + kakaoApiKey)
 				.retrieve()
-				.bodyToMono(KakaoMapApiResponse.class);
+				.bodyToMono(KakaoMapApiResponseDto.class);
 	}
 }

--- a/src/main/java/purureum/pudongpudong/infrastructure/adapter/api/KakaoNaviApiService.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/adapter/api/KakaoNaviApiService.java
@@ -1,0 +1,50 @@
+package purureum.pudongpudong.infrastructure.adapter.api;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import purureum.pudongpudong.infrastructure.dto.api.KakaoNaviApiRequestDto;
+import purureum.pudongpudong.infrastructure.dto.api.KakaoNaviApiResponseDto;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class KakaoNaviApiService {
+	
+	private final WebClient webClient;
+	private final String kakaoApiKey;
+	
+	public KakaoNaviApiService(WebClient.Builder webClientBuilder,
+								@Value("${kakao.navi.url") String kakaoNaviUrl,
+								@Value("${kakao.api.key}") String kakaoApiKey) {
+		this.webClient = webClientBuilder.baseUrl(kakaoNaviUrl).build();
+		this.kakaoApiKey = kakaoApiKey;
+	}
+	
+	public Mono<KakaoNaviApiResponseDto> getWalkingRoutes(List<KakaoNaviApiRequestDto.Destination> destinations, double longitude, double latitude) {
+		if(destinations.size() > 15) {
+			return Mono.error(new IllegalArgumentException("목적지는 최대 15개만 지정할 수 있습니다."));
+		}
+		
+		KakaoNaviApiRequestDto requestBody = new KakaoNaviApiRequestDto();
+		requestBody.setOrigin(new KakaoNaviApiRequestDto.Origin(String.valueOf(longitude), String.valueOf(latitude)));
+		requestBody.setDestinations(destinations.stream()
+				.map(d -> new KakaoNaviApiRequestDto.Destination(d.getKey(), d.getX(), d.getY()))
+				.collect(Collectors.toList()));
+		requestBody.setRadius(5000);
+		
+		return webClient.post()
+				.uri("/v1/destinations/directions")
+				.header(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoApiKey)
+				.contentType(MediaType.APPLICATION_JSON)
+				.bodyValue(requestBody)
+				.retrieve()
+				.bodyToMono(KakaoNaviApiResponseDto.class);
+	}
+	
+	
+}

--- a/src/main/java/purureum/pudongpudong/infrastructure/adapter/api/KakaoNaviApiService.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/adapter/api/KakaoNaviApiService.java
@@ -1,10 +1,14 @@
 package purureum.pudongpudong.infrastructure.adapter.api;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import purureum.pudongpudong.global.apiPayload.code.status.ErrorStatus;
+import purureum.pudongpudong.global.apiPayload.exception.handler.ApiHandler;
 import purureum.pudongpudong.infrastructure.dto.api.KakaoNaviApiRequestDto;
 import purureum.pudongpudong.infrastructure.dto.api.KakaoNaviApiResponseDto;
 import reactor.core.publisher.Mono;
@@ -12,6 +16,7 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 public class KakaoNaviApiService {
 	
@@ -19,7 +24,7 @@ public class KakaoNaviApiService {
 	private final String kakaoApiKey;
 	
 	public KakaoNaviApiService(WebClient.Builder webClientBuilder,
-								@Value("${kakao.navi.url") String kakaoNaviUrl,
+								@Value("${kakao.navi.url}") String kakaoNaviUrl,
 								@Value("${kakao.api.key}") String kakaoApiKey) {
 		this.webClient = webClientBuilder.baseUrl(kakaoNaviUrl).build();
 		this.kakaoApiKey = kakaoApiKey;
@@ -43,6 +48,22 @@ public class KakaoNaviApiService {
 				.contentType(MediaType.APPLICATION_JSON)
 				.bodyValue(requestBody)
 				.retrieve()
+				.onStatus(HttpStatusCode::is4xxClientError, response ->
+						response.bodyToMono(String.class)
+								.map(body -> {
+									log.error("카카오 네비 API 호출에 실패 || 4xx 코드 : {}, response body: {}", response.statusCode(), body);
+									return new ApiHandler(ErrorStatus.KAKAO_NAVI_API_BAD_REQUEST);
+								})
+								.flatMap(Mono::error)
+				)
+				.onStatus(HttpStatusCode::is5xxServerError, response ->
+						response.bodyToMono(String.class)
+								.map(body -> {
+									log.error("카카오 네비 API 호출에 실패 || 5xx 코드 : {}, response body: {}", response.statusCode(), body);
+									return new ApiHandler(ErrorStatus.KAKAO_NAVI_API_SERVER_ERROR);
+								})
+								.flatMap(Mono::error)
+				)
 				.bodyToMono(KakaoNaviApiResponseDto.class);
 	}
 	

--- a/src/main/java/purureum/pudongpudong/infrastructure/adapter/controller/ParkController.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/adapter/controller/ParkController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import purureum.pudongpudong.application.command.ParkCommandService;
 import purureum.pudongpudong.application.query.ParkQueryService;
 import purureum.pudongpudong.global.apiPayload.ApiResponse;
+import purureum.pudongpudong.infrastructure.dto.ParkDetailResponseDto;
 import purureum.pudongpudong.infrastructure.dto.ParkResponseDto;
 import reactor.core.publisher.Mono;
 
@@ -28,6 +29,14 @@ public class ParkController {
 	public Mono<ApiResponse<List<ParkResponseDto>>> getParkMap(@RequestParam Double x,
 															   @RequestParam Double y) {
 		return parkQueryService.getAllParksWithMyLocation(x, y).collectList().map(ApiResponse::onSuccess);
+	}
+	
+	@Operation(
+			summary = "공원 검색 API",
+			description = "키워드로 공원을 검색합니다.")
+	@GetMapping("/search")
+	public ApiResponse<List<ParkDetailResponseDto>> searchParks(@RequestParam String keyword) {
+		return ApiResponse.onSuccess(parkQueryService.searchParksByKeyword(keyword));
 	}
 	
 }

--- a/src/main/java/purureum/pudongpudong/infrastructure/adapter/controller/ParkController.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/adapter/controller/ParkController.java
@@ -3,25 +3,31 @@ package purureum.pudongpudong.infrastructure.adapter.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+import purureum.pudongpudong.application.command.ParkCommandService;
+import purureum.pudongpudong.application.query.ParkQueryService;
 import purureum.pudongpudong.global.apiPayload.ApiResponse;
+import purureum.pudongpudong.infrastructure.dto.ParkResponseDto;
+import reactor.core.publisher.Mono;
 
-@Controller
+import java.util.List;
+
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/addresses")
 @Tag(name = "Park API", description = "공원 페이지와 관련된 API입니다.")
 public class ParkController {
 	
+	private final ParkQueryService parkQueryService;
+	private final ParkCommandService parkCommandService;
+	
 	@Operation(
 			summary = "공원 지도 API",
 			description = "공원들의 좌표를 조회합니다.")
 	@PostMapping
-	public ApiResponse<String> getParkMap(Long memberId,
-										  double x, double y) {
-		
-		return ApiResponse.onSuccess("");
+	public Mono<ApiResponse<List<ParkResponseDto>>> getParkMap(@RequestParam Double x,
+															   @RequestParam Double y) {
+		return parkQueryService.getAllParksWithMyLocation(x, y).collectList().map(ApiResponse::onSuccess);
 	}
 	
 }

--- a/src/main/java/purureum/pudongpudong/infrastructure/adapter/controller/ParkController.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/adapter/controller/ParkController.java
@@ -1,0 +1,27 @@
+package purureum.pudongpudong.infrastructure.adapter.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import purureum.pudongpudong.global.apiPayload.ApiResponse;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/addresses")
+@Tag(name = "Park API", description = "공원 페이지와 관련된 API입니다.")
+public class ParkController {
+	
+	@Operation(
+			summary = "공원 지도 API",
+			description = "공원들의 좌표를 조회합니다.")
+	@PostMapping
+	public ApiResponse<String> getParkMap(Long memberId,
+										  double x, double y) {
+		
+		return ApiResponse.onSuccess("");
+	}
+	
+}

--- a/src/main/java/purureum/pudongpudong/infrastructure/batch/ParkSyncJob.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/batch/ParkSyncJob.java
@@ -1,0 +1,25 @@
+package purureum.pudongpudong.infrastructure.batch;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import purureum.pudongpudong.application.command.ParkCommandService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ParkSyncJob {
+	
+	private final ParkCommandService parkCommandService;
+	
+	@PostConstruct
+	@Scheduled(cron = "0 0 3 1 * *")
+	public void initParksData() {
+		parkCommandService.saveAllParks()
+				.doOnComplete(() -> log.info("공원 데이터 배치 작업 완료"))
+				.doOnError(throwable -> log.error("배치 작업 중 에러 발생: {}", throwable.getMessage())) // 에러 핸들러 추가
+				.subscribe();
+	}
+}

--- a/src/main/java/purureum/pudongpudong/infrastructure/batch/ParkSyncJob.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/batch/ParkSyncJob.java
@@ -1,6 +1,6 @@
 package purureum.pudongpudong.infrastructure.batch;
 
-import jakarta.annotation.PostConstruct;
+//import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -14,7 +14,7 @@ public class ParkSyncJob {
 	
 	private final ParkCommandService parkCommandService;
 	
-	@PostConstruct
+//	@PostConstruct
 	@Scheduled(cron = "0 0 3 1 * *")
 	public void initParksData() {
 		parkCommandService.saveAllParks()

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/FairyDto.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/FairyDto.java
@@ -1,0 +1,23 @@
+package purureum.pudongpudong.infrastructure.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import purureum.pudongpudong.domain.model.Fairy;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FairyDto {
+	String name;
+	String description;
+	
+	public static FairyDto toDto(Fairy fairy) {
+		return FairyDto.builder()
+				.name(fairy.getName())
+				.description(fairy.getDescription())
+				.build();
+	}
+}

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/KakaoMapApiResponse.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/KakaoMapApiResponse.java
@@ -1,0 +1,19 @@
+package purureum.pudongpudong.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class KakaoMapApiResponse {
+	@JsonProperty("documents")
+	private List<ParkDto> parks;
+	
+	@JsonProperty("meta")
+	private MetaDto meta;
+}

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/MetaDto.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/MetaDto.java
@@ -1,0 +1,18 @@
+package purureum.pudongpudong.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MetaDto {
+
+	@JsonProperty("is_end")
+	private boolean isEnd;
+	
+	@JsonProperty("total_count")
+	private boolean totalCount;
+}

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/ParkDetailResponseDto.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/ParkDetailResponseDto.java
@@ -1,0 +1,25 @@
+package purureum.pudongpudong.infrastructure.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import purureum.pudongpudong.domain.model.enums.ParkDifficulty;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ParkDetailResponseDto {
+	String name;
+	String description;
+	FairyDto fairy;
+	List<String> tags;
+	ParkDifficulty difficulty;
+	double averageRating;
+	int reviewCount;
+	// TODO: Boolean isVisited; 추가
+	// TODO: distance, time 필요 시 추가
+}

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/ParkDto.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/ParkDto.java
@@ -1,0 +1,49 @@
+package purureum.pudongpudong.infrastructure.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import purureum.pudongpudong.domain.model.Park;
+import purureum.pudongpudong.domain.model.enums.ParkDifficulty;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ParkDto {
+	
+	@JsonProperty("id")
+	private String id;
+	
+	@JsonProperty("place_name")
+	private String placeName;
+	
+	@JsonProperty("address_name")
+	private String addressName;
+	
+	@JsonProperty("road_address_name")
+	private String roadAddressName;
+	
+	@JsonProperty("y")
+	private String latitude;
+	
+	@JsonProperty("x")
+	private String longitude;
+	
+	@JsonProperty("place_url")
+	private String placeUrl;
+	
+	public Park toEntity() {
+		return Park.builder()
+				.id(this.getId())
+				.placeName(this.getPlaceName())
+				.addressName(this.getAddressName())
+				.roadAddressName(this.getRoadAddressName())
+				.latitude(Double.parseDouble(this.getLatitude()))
+				.longitude(Double.parseDouble(this.getLongitude()))
+				.placeUrl(this.getPlaceUrl())
+				.description("설명 정보가 없습니다.")
+				.difficulty(ParkDifficulty.NORMAL)
+				.build();
+	}
+}

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/ParkDto.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/ParkDto.java
@@ -32,9 +32,6 @@ public class ParkDto {
 	@JsonProperty("y")
 	private String latitude;
 	
-	@JsonProperty("place_url")
-	private String placeUrl;
-	
 	public Park toEntity() {
 		return Park.builder()
 				.id(this.getId())
@@ -43,7 +40,6 @@ public class ParkDto {
 				.roadAddressName(this.getRoadAddressName())
 				.latitude(Double.parseDouble(this.getLatitude()))
 				.longitude(Double.parseDouble(this.getLongitude()))
-				.placeUrl(this.getPlaceUrl())
 				.description("설명 정보가 없습니다.")
 				.difficulty(ParkDifficulty.NORMAL)
 				.build();

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/ParkDto.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/ParkDto.java
@@ -1,6 +1,7 @@
 package purureum.pudongpudong.infrastructure.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,6 +11,7 @@ import purureum.pudongpudong.domain.model.enums.ParkDifficulty;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ParkDto {
 	
 	@JsonProperty("id")
@@ -24,11 +26,11 @@ public class ParkDto {
 	@JsonProperty("road_address_name")
 	private String roadAddressName;
 	
-	@JsonProperty("y")
-	private String latitude;
-	
 	@JsonProperty("x")
 	private String longitude;
+	
+	@JsonProperty("y")
+	private String latitude;
 	
 	@JsonProperty("place_url")
 	private String placeUrl;

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/ParkResponseDto.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/ParkResponseDto.java
@@ -1,0 +1,39 @@
+package purureum.pudongpudong.infrastructure.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import purureum.pudongpudong.domain.model.Park;
+import purureum.pudongpudong.domain.model.enums.ParkDifficulty;
+import purureum.pudongpudong.infrastructure.dto.api.KakaoNaviApiResponseDto;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ParkResponseDto {
+	String id;
+	String name;
+	String description;
+	ParkDifficulty difficulty;
+	Boolean isVisited;
+	Double longitude;
+	Double latitude;
+	Integer distance;
+	Integer time;
+	
+	public static ParkResponseDto toDto(Park park, KakaoNaviApiResponseDto.Route response) {
+		return ParkResponseDto.builder()
+				.id(park.getId())
+				.name(park.getPlaceName())
+				.description(park.getDescription())
+				.difficulty(park.getDifficulty())
+				.isVisited(false)
+				.longitude(park.getLongitude())
+				.latitude(park.getLatitude())
+				.distance(response.getSummary().getDistance())
+				.time(response.getSummary().getDuration()/60)
+				.build();
+	}
+}

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/api/KakaoMapApiResponseDto.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/api/KakaoMapApiResponseDto.java
@@ -1,16 +1,17 @@
-package purureum.pudongpudong.infrastructure.dto;
+package purureum.pudongpudong.infrastructure.dto.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import purureum.pudongpudong.infrastructure.dto.ParkDto;
 
 import java.util.List;
 
 @Getter
 @Setter
 @NoArgsConstructor
-public class KakaoMapApiResponse {
+public class KakaoMapApiResponseDto {
 	@JsonProperty("documents")
 	private List<ParkDto> parks;
 	

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/api/KakaoNaviApiRequestDto.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/api/KakaoNaviApiRequestDto.java
@@ -1,0 +1,38 @@
+package purureum.pudongpudong.infrastructure.dto.api;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoNaviApiRequestDto {
+	
+	private Origin origin;
+	private List<Destination> destinations;
+	private int radius;
+	
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Origin {
+		private String x;
+		private String y;
+	}
+	
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Destination {
+		private String key;
+		private String x;
+		private String y;
+	}
+}

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/api/KakaoNaviApiResponseDto.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/api/KakaoNaviApiResponseDto.java
@@ -23,7 +23,7 @@ public class KakaoNaviApiResponseDto {
 		private int code;
 		
 		@JsonProperty("result_msg")
-		private int message;
+		private String message;
 		
 		@JsonProperty("summary")
 		private Summary summary;

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/api/KakaoNaviApiResponseDto.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/api/KakaoNaviApiResponseDto.java
@@ -1,0 +1,43 @@
+package purureum.pudongpudong.infrastructure.dto.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class KakaoNaviApiResponseDto {
+	
+	@JsonProperty("routes")
+	private List<Route> routes;
+	
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	public static class Route {
+		@JsonProperty("result_code")
+		private int code;
+		
+		@JsonProperty("result_msg")
+		private int message;
+		
+		@JsonProperty("summary")
+		private Summary summary;
+	}
+	
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	public static class Summary {
+		@JsonProperty("distance")
+		private int distance;
+		
+		@JsonProperty("duration")
+		private int duration;
+	}
+	
+}

--- a/src/main/java/purureum/pudongpudong/infrastructure/dto/api/MetaDto.java
+++ b/src/main/java/purureum/pudongpudong/infrastructure/dto/api/MetaDto.java
@@ -1,4 +1,4 @@
-package purureum.pudongpudong.infrastructure.dto;
+package purureum.pudongpudong.infrastructure.dto.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;


### PR DESCRIPTION
## 🌟 제목
feat: 공원 지도/검색 API 구현

### 🔗 관련 이슈
- closes #2 

### 📝 주요 변경 사항
1. Park, Tag, ParkTag, Review, Fairy 엔티티를 생성했습니다. (`/domain/model`)
2. Kakao Map API를 사용하여 매달 1일 오전 3시마다 "동대문구 공원" 키워드에 해당하는 공원들의 데이터를 저장합니다. (`/infrastructure/adapter/api/KakaoMapApiService`)
3. Kakao Navi API를 사용하여 받아온 현재 위치~공원들까지의 거리/걸리는 시간을 받아올 수 있게 구현했습니다. (`/infrastructure/adapter/api/KakaoNaviApiService`)
4. querydsl 누락한 설정을 발견해 추가했습니다.
5. 공원 지도 API를 구현했습니다.
6. 공원 검색 API를 구현했습니다.
7. 페이징 처리 시 공통으로 사용할 PageResponse 객체 생성했습니다. (`src/main/java/purureum/pudongpudong/global/apiPayload/code/PageResponse.java`)

### 🖼️ 스크린샷
공원 지도 API (외부 api 한계로 인해 현재 위치로부터 반경 5km 내 공원 최대 15개만 검색)
<img width="473" height="518" alt="Screenshot 2025-08-12 at 16 50 25" src="https://github.com/user-attachments/assets/d1a008e5-dec4-42ea-8d8e-effdf916f663" />

공원 검색 API (placeName 기준)
<img width="463" height="748" alt="Screenshot 2025-08-12 at 21 21 46" src="https://github.com/user-attachments/assets/4fe4aa16-95ce-4ac7-b209-e9bf16cd0bf7" />


### 🚀 테스트 방법
**.env 파일 수정됐으니 수정해서 테스트**해야 합니다.
그리고 **반드시 `/infrastructure/adapter/api/KakaoMapApiService` 내 주석 처리되어 있는 `@PostConstruct`를 주석 해제하고 실행해 데이터베이스에 공원 데이터들을 한 번 저장 후 재주석처리해주세요!!**

### 🔍 리뷰 포인트
User 관련 TODO 있는데 파일 겹치는 걸 우려해 일단 제외하고 진행했습니다. 추후 수정할게요!

---
**PR을 올리기 전에 아래 사항들을 모두 확인해주세요.**
- [x] PR 제목은 작업 유형으로 시작합니다. (feat, fix, refactor 등)
- [x] 커밋 메시지는 깔끔하게 작성됐습니다.
- [x] 코드에 불필요한 변경 사항(e.g., 주석, console.log)이 없습니다.
- [x] 로컬 환경에서 모든 테스트를 통과했습니다.
- [x] 기능 추가/수정의 경우, 관련 문서(API 명세서, README 등)를 업데이트했습니다.
